### PR TITLE
Ensure module is loaded in Configuration

### DIFF
--- a/lib/faktory/configuration.ex
+++ b/lib/faktory/configuration.ex
@@ -29,6 +29,12 @@ defmodule Faktory.Configuration do
     {:ok, modules} = :application.get_key(otp_app, :modules)
 
     Enum.reduce(modules, %{}, fn module, acc ->
+    
+      # Trying to call a function on a module will implicitly load it, but
+      # function_exported?/1 will return false on unloaded modules, so we
+      # have to make sure the module is loaded before calling it.
+      {:module, ^module} = Code.ensure_loaded(module)
+      
       behaviours =
         cond do
           Kernel.function_exported?(module, :__info__, 1) ->


### PR DESCRIPTION
From https://github.com/cjbottaro/faktory_worker_ex/blob/0312cbe84ae6baa7a2d9bb2e27a784b113800610/lib/faktory/configuration.ex#L43

```
Trying to call a function on a module will implicitly load it, but function_exported?/1 will return false on unloaded modules, so we have to make sure the module is loaded before calling it.
```